### PR TITLE
add keyboard shortcuts for displaying the payload on the second screen

### DIFF
--- a/src/PayLoad/payload.cc
+++ b/src/PayLoad/payload.cc
@@ -4,6 +4,7 @@
 #include "Vehicle.h"
 #include "MultiVehicleManager.h"
 #include "LinkManager.h"
+#include <QWindow>
 
 QGC_LOGGING_CATEGORY(PayloadControllerLog, "PayloadControllerLog")
 
@@ -248,4 +249,31 @@ void PayloadLogDownloaderThread::run()
             qDebug() << "Error downloading file:" << m_file_name << process.errorString();
         }
     }
+}
+
+MonitorManager::MonitorManager(QObject *parent) : QObject(parent)
+{
+}
+
+int MonitorManager::targetScreenIndexForWindow(QWindow *window)
+{
+    QScreen *currentScreen = window ? window->screen() : nullptr;
+    if (!currentScreen)
+        return -1;
+
+    int targetScreenIndex = findScreenIndexOtherThan(currentScreen->geometry().center());
+    return targetScreenIndex;
+}
+
+int MonitorManager::findScreenIndexOtherThan(const QPoint &currentScreenCenter)
+{
+    QList<QScreen *> screens = QGuiApplication::screens();
+    for (int i = 0; i < screens.size(); ++i)
+    {
+        if (!screens[i]->geometry().contains(currentScreenCenter))
+        {
+            return i;
+        }
+    }
+    return -1;
 }

--- a/src/PayLoad/payload.h
+++ b/src/PayLoad/payload.h
@@ -8,11 +8,29 @@
 #include "QGCToolbox.h"
 #include <QThread>
 
+#include <QGuiApplication>
+#include <QScreen>
+
+
 class  MultiVehicleManager;
 class  Vehicle;
 class LinkInterface;
 
 Q_DECLARE_LOGGING_CATEGORY(PayloadControllerLog)
+
+
+class MonitorManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit MonitorManager(QObject *parent = nullptr);
+
+    Q_INVOKABLE int targetScreenIndexForWindow(QWindow *window);
+
+private:
+    int findScreenIndexOtherThan(const QPoint &currentScreenCenter);
+};
 
 class PingThread : public QThread
 {

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -516,6 +516,7 @@ void QGCApplication::_initCommon()
     qmlRegisterType<PayloadController>          (kQGCControllers,                       1, 0, "PayloadController");
     qmlRegisterType<NvidiaStateDetector>          (kQGCControllers,                       1, 0, "NvidiaStateDetector");
     qmlRegisterType<PayloadLogDownloader>          (kQGCControllers,                       1, 0, "PayloadLogDownloader");
+    qmlRegisterType<MonitorManager>                 (kQGCControllers,                        1, 0, "MonitorManager");
     qmlRegisterType<SyslinkComponentController>     (kQGCControllers,                       1, 0, "SyslinkComponentController");
     qmlRegisterType<EditPositionDialogController>   (kQGCControllers,                       1, 0, "EditPositionDialogController");
     qmlRegisterType<RCToParamDialogController>      (kQGCControllers,                       1, 0, "RCToParamDialogController");

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -183,6 +183,7 @@ ApplicationWindow {
 
     function showPayloadTool() {
         var targetScreenIndex = monitorManager.targetScreenIndexForWindow(mainWindow);
+        if (targetScreenIndex<0)targetScreenIndex=0;
         console.log("target index  ",targetScreenIndex)
         if (payloadWindowObject === null) {
             payloadWindowObject = payloadWindowComponent.createObject(null);


### PR DESCRIPTION
This commit brings 2 features:

1. Payload window will now open on second screen (Maximized on the whole screen) if available otherwise it will open on same screen
2. you can enter payload page directly by clicking on P button in keyboard